### PR TITLE
Fix drawSeconds to run in low power mode.

### DIFF
--- a/source/GoalDrawable.mc
+++ b/source/GoalDrawable.mc
@@ -18,7 +18,7 @@ class GoalDrawable extends OrbitDrawable {
     }
     
     function draw(dc) {
-        if (Application.Properties.getValue(goalTypeName) == -1) {
+        if (getApp().properties[goalTypeName] == -1) {
             return;
         }
         

--- a/source/OrbitApp.mc
+++ b/source/OrbitApp.mc
@@ -7,6 +7,7 @@ class OrbitApp extends Application.AppBase {
 
     function initialize() {
         AppBase.initialize();
+        loadProperties();
     }
 
     // onStart() is called on application start up
@@ -29,6 +30,29 @@ class OrbitApp extends Application.AppBase {
     }
     
     function onSettingsChanged() {
+        loadProperties();
         WatchUi.requestUpdate();
     }
+
+    var properties = {};
+
+    private function loadProperties() {
+        properties.put(Properties.showSeconds, Application.Properties.getValue(Properties.showSeconds));
+        properties.put(Properties.theme, Application.Properties.getValue(Properties.theme));
+        properties.put(Properties.backgroundColor, Application.Properties.getValue(Properties.backgroundColor));
+        properties.put(Properties.hoursColor, Application.Properties.getValue(Properties.hoursColor));
+        properties.put(Properties.minutesColor, Application.Properties.getValue(Properties.minutesColor));
+        properties.put(Properties.secondsColor, Application.Properties.getValue(Properties.secondsColor));
+        properties.put(Properties.outerGoalColor, Application.Properties.getValue(Properties.outerGoalColor));
+        properties.put(Properties.innerGoalColor, Application.Properties.getValue(Properties.innerGoalColor));
+        properties.put(Properties.dateColor, Application.Properties.getValue(Properties.dateColor));
+        properties.put(Properties.batteryColor, Application.Properties.getValue(Properties.batteryColor));
+        properties.put(Properties.outerGoalType, Application.Properties.getValue(Properties.outerGoalType));
+        properties.put(Properties.innerGoalType, Application.Properties.getValue(Properties.innerGoalType));
+        properties.put(Properties.caloriesGoal, Application.Properties.getValue(Properties.caloriesGoal));
+    }
+}
+
+function getApp() as OrbitApp {
+    return Application.getApp() as OrbitApp;
 }

--- a/source/OrbitDrawable.mc
+++ b/source/OrbitDrawable.mc
@@ -12,11 +12,12 @@ class OrbitDrawable extends WatchUi.Drawable {
         screenCenterX = screenWidth / 2;
         screenCenterY = screenHeight / 2;
     }
-    
+
     protected function getColor(colorPropertyName) {
-        var color = Application.Properties.getValue(colorPropertyName);
+        var properties = getApp().properties;
+        var color = properties[colorPropertyName];
         if (color == -1) {
-            var theme = Application.Properties.getValue(Properties.theme);
+            var theme = properties[Properties.theme];
             return themeColors[colorPropertyName][theme];
         }
         

--- a/source/OrbitView.mc
+++ b/source/OrbitView.mc
@@ -49,10 +49,10 @@ class OrbitView extends WatchUi.WatchFace {
     }
 
     private function updateGoals() {
-        var outerGoalType = Application.Properties.getValue(Properties.outerGoalType);
+        var outerGoalType = getApp().properties[Properties.outerGoalType];
         var outerGoalValues = getGoalValues(outerGoalType);
         outerGoalDrawable.setGoalValues(outerGoalValues[:current], outerGoalValues[:goal], outerGoalType);
-        var innerGoalType = Application.Properties.getValue(Properties.innerGoalType);
+        var innerGoalType = getApp().properties[Properties.innerGoalType];
         var innerGoalValues = getGoalValues(innerGoalType);
         innerGoalDrawable.setGoalValues(innerGoalValues[:current], innerGoalValues[:goal], innerGoalType);
     }
@@ -78,7 +78,7 @@ class OrbitView extends WatchUi.WatchFace {
                 break;
             case OrbitApp.GOAL_TYPE_CALORIES:
                 values[:current] = info.calories;
-                values[:goal] = Application.Properties.getValue(Properties.caloriesGoal);
+                values[:goal] = getApp().properties[Properties.caloriesGoal];
                 break;
         }
 

--- a/source/Properties.mc
+++ b/source/Properties.mc
@@ -1,6 +1,4 @@
 module Properties {
-    const showOuterGoal = "ShowOuterGoal";
-    const showInnerGoal = "ShowInnerGoal";
     const showSeconds = "ShowSeconds";
     const theme = "Theme";
     const backgroundColor = "BackgroundColor";


### PR DESCRIPTION
This PR fixes drawSeconds to run in low power mode. Getting properties through the Application.Properties module turns out to be expensive. Additionally, this change precomputes the clipping rectangles for each arc segment.